### PR TITLE
Add a server 'headers' event to handle SOAP Headers globally

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -104,6 +104,37 @@ object with a `Fault` property.
   };
 ```
 
+### SOAP Headers
+
+A service method can look at the SOAP headers by providing a 3rd arguments.
+
+``` javascript
+  {
+      HeadersAwareFunction: function(args, cb, headers) {
+          return {
+              name: headers.Token
+          };
+      }
+  }
+```
+
+It is also possible to subscribe to the 'headers' event.
+The event is triggered before the service method is called, and only when the
+SOAP Headers are not empty.
+
+``` javascript
+  server = soap.listen(...)
+  server.on('headers', function(headers, methodName) {
+    // It is possible to change the value of the headers
+    // before they are handed to the service method.
+    // It is also possible to throw a SOAP Fault
+  });
+```
+
+First parameter is the Headers object;
+second parameter is the name of the SOAP method that will called
+(in case you need to handle the headers differently based on the method).
+
 ### server security example using PasswordDigest
 
 If server.authenticate is not defined no authentation will take place.

--- a/lib/server.js
+++ b/lib/server.js
@@ -12,7 +12,9 @@ function findKey(obj, val) {
 }
 
 var url = require('url'),
-  compress = null;
+  compress = null,
+  events = require('events'),
+  util = require('util');
 
 try {
   compress = require("compress");
@@ -21,6 +23,8 @@ try {
 
 var Server = function(server, path, services, wsdl, options) {
   var self = this;
+
+  events.EventEmitter.call(this);
 
   options = options || {};
   this.path = path;
@@ -55,6 +59,7 @@ var Server = function(server, path, services, wsdl, options) {
 
   this._initializeOptions(options);
 };
+util.inherits(Server, events.EventEmitter);
 
 Server.prototype._initializeOptions = function(options) {
   this.wsdl.options.attributesKey = options.attributesKey || 'attributes';
@@ -186,6 +191,10 @@ Server.prototype._process = function(input, URL, callback) {
   try {
     if (binding.style === 'rpc') {
       methodName = Object.keys(body)[0];
+
+      if (headers)
+        self.emit('headers', headers, methodName);
+
       self._executeMethod({
         serviceName: serviceName,
         portName: portName,
@@ -198,6 +207,10 @@ Server.prototype._process = function(input, URL, callback) {
     } else {
       var messageElemName = Object.keys(body)[0];
       var pair = binding.topElements[messageElemName];
+
+      if (headers)
+        self.emit('headers', headers, pair.methodName);
+
       self._executeMethod({
         serviceName: serviceName,
         portName: portName,


### PR DESCRIPTION
Add support for 'headers' events on the server side, on incoming requests.
The callback has access to the all headers + called method name.
The callback can modify the headers, before the service method is called.
The callback can also throw a SOAP Fault.